### PR TITLE
Add react router

### DIFF
--- a/app/javascript/constants/paths.js
+++ b/app/javascript/constants/paths.js
@@ -1,0 +1,1 @@
+export const rootPath = '/'

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,14 +2,14 @@
 import React from 'react'
 import { render } from 'react-dom'
 
-import App from '../react/components/App'
+import App from '../react/components/app/root/index.jsx'
 import RedBox from 'redbox-react'
 
 document.addEventListener('DOMContentLoaded', () => {
   let reactElement = document.getElementById('app')
 
   if (reactElement) {
-    if(window.railsEnv && window.railsEnv === 'development'){
+    if (window.railsEnv && window.railsEnv === 'development') {
       try {
         render(<App />, reactElement)
       } catch (e) {

--- a/app/javascript/react/components/App.js
+++ b/app/javascript/react/components/App.js
@@ -1,7 +1,0 @@
-import React from 'react'
-
-export const App = (props) => {
-  return (<h1>Ecommerce Site</h1>)
-}
-
-export default App

--- a/app/javascript/react/components/app/root/history.js
+++ b/app/javascript/react/components/app/root/history.js
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export default createBrowserHistory();

--- a/app/javascript/react/components/app/root/index.jsx
+++ b/app/javascript/react/components/app/root/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Route, Switch, Router } from 'react-router-dom';
+import history from './history';
+import { rootPath } from 'constants/paths'
+
+import HomePageRoot from '../../home-page/root/index.jsx'
+
+export const App = (props) => {
+  return (
+    <Router history={history}>
+      <Switch>
+        <Route component={HomePageRoot} exact path={rootPath} />
+      </Switch>
+    </Router>
+  )
+}
+
+export default App

--- a/app/javascript/react/components/app/root/index.test.jsx
+++ b/app/javascript/react/components/app/root/index.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import App from './index.jsx'
+
+describe('second test', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<App />);
+  });
+
+  it('should render a Router component', () => {
+    const router = wrapper.find('Router')
+    expect(router).toBeTruthy()
+  })
+})

--- a/app/javascript/react/components/home-page/root/index.jsx
+++ b/app/javascript/react/components/home-page/root/index.jsx
@@ -1,0 +1,9 @@
+import React, { useState } from 'react';
+
+function HomePageRoot() {
+  const [welcome, setWelcome] = useState('Welcome to Ecommerce Site!')
+
+  return <h1>{welcome}</h1>;
+}
+
+export default HomePageRoot

--- a/app/javascript/react/components/home-page/root/index.test.jsx
+++ b/app/javascript/react/components/home-page/root/index.test.jsx
@@ -1,5 +1,18 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import HomePageRoot from './index.jsx'
+import { cleanup } from 'react-testing-library';
+
+afterEach(cleanup)
+
 describe('second test', () => {
-  it('should be true if true', () => {
-    expect(true).toBe(true)
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<HomePageRoot />);
+  });
+
+  it('should render a HomePageRoot component', () => {
+    expect(wrapper).toBeTruthy()
   })
 })

--- a/app/javascript/react/components/home-page/root/index.test.jsx
+++ b/app/javascript/react/components/home-page/root/index.test.jsx
@@ -1,0 +1,5 @@
+describe('second test', () => {
+  it('should be true if true', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "dependencies": {
     "@rails/webpacker": "3.5",
     "babel-core": "^7.0.0-bridge.0",
+    "jest-watch-typeahead": "^0.4.0",
     "prop-types": "~15.6.0",
     "react": "~16.8.0",
     "react-dom": "~16.8.0",
     "react-router-dom": "5.0.0",
+    "react-testing-library": "^6.0.0",
     "redbox-react": "1.6.0"
   },
   "devDependencies": {
@@ -34,9 +36,8 @@
   },
   "jest": {
     "automock": false,
-    "roots": [
-      "spec/javascript",
-      "app/javascript"
+    "collectCoverageFrom": [
+      "app/javascript/*.{js,jsx}"
     ],
     "moduleDirectories": [
       "node_modules",
@@ -45,6 +46,13 @@
     "setupFiles": [
       "./spec/javascript/support/enzyme.js"
     ],
-    "testURL": "http://localhost/"
+    "testPathIgnorePatterns": [
+      "<rootDir>[/\\\\](node_modules|scripts|server|config)[/\\\\]"
+    ],
+    "testURL": "http://localhost/",
+    "watchPlugins": [
+      "jest-watch-typeahead/filename",
+      "jest-watch-typeahead/testname"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
   "scripts": {
     "start": "./bin/webpack-dev-server",
     "test": "node_modules/.bin/jest",
-    "test:dev": "node_modules/.bin/jest --notify --watch"
+    "test:dev": "node_modules/.bin/jest --watch"
   },
   "jest": {
     "automock": false,
     "roots": [
-      "spec/javascript"
+      "spec/javascript",
+      "app/javascript"
     ],
     "moduleDirectories": [
       "node_modules",

--- a/spec/javascript/test.test.js
+++ b/spec/javascript/test.test.js
@@ -1,5 +1,0 @@
-describe('test', () => {
-  it('should be true if true', () => {
-    expect(true).toBe(true)
-  })
-})

--- a/yarn.lock
+++ b/yarn.lock
@@ -693,7 +693,7 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/runtime@^7.1.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.3":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
   integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
@@ -940,6 +940,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -1142,6 +1147,13 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+
+ansi-escapes@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.2.1.tgz#4dccdb846c3eee10f6d64dea66273eab90c37228"
+  integrity sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==
+  dependencies:
+    type-fest "^0.5.2"
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -3877,6 +3889,16 @@ dom-serializer@~0.1.1:
     domelementtype "^1.3.0"
     entities "^1.1.1"
 
+dom-testing-library@^3.19.0:
+  version "3.19.4"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.19.4.tgz#f5b737f59ee9749a4568fa353f1f59be97c888c3"
+  integrity sha512-GJOx8CLpnkvM3takILOsld/itUUc9+7Qh6caN1Spj6+9jIgNPY36fsvoH7sEgYokC0lBRdttO7G7fIFYCXlmcA==
+  dependencies:
+    "@babel/runtime" "^7.4.3"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^24.7.0"
+    wait-for-expect "^1.1.1"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -6501,7 +6523,19 @@ jest-validate@^24.9.0:
     leven "^3.1.0"
     pretty-format "^24.9.0"
 
-jest-watcher@^24.9.0:
+jest-watch-typeahead@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.4.0.tgz#4d5356839a85421588ce452d2440bf0d25308397"
+  integrity sha512-bJR/HPNgOQnkmttg1OkBIrYFAYuxFxExtgQh67N2qPvaWGVC8TCkedRNPKBfmZfVXFD3u2sCH+9OuS5ApBfCgA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.1"
+    jest-watcher "^24.3.0"
+    slash "^3.0.0"
+    string-length "^3.1.0"
+    strip-ansi "^5.0.0"
+
+jest-watcher@^24.3.0, jest-watcher@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.9.0.tgz#4b56e5d1ceff005f5b88e528dc9afc8dd4ed2b3b"
   integrity sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==
@@ -9210,7 +9244,7 @@ pretty-bytes@^4.0.2:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
   integrity sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=
 
-pretty-format@^24.9.0:
+pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -9525,6 +9559,14 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.2"
     react-is "^16.9.0"
     scheduler "^0.15.0"
+
+react-testing-library@^6.0.0:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-6.1.2.tgz#f6bba6eeecedac736eb00b22b4c70bae04535a4f"
+  integrity sha512-z69lhRDGe7u/NOjDCeFRoe1cB5ckJ4656n0tj/Fdcr6OoBUu7q9DBw0ftR7v5i3GRpdSWelnvl+feZFOyXyxwg==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    dom-testing-library "^3.19.0"
 
 react@~16.8.0:
   version "16.8.6"
@@ -10372,6 +10414,11 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
@@ -10678,6 +10725,14 @@ string-length@^2.0.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
+
+string-length@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"
+  integrity sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^5.2.0"
 
 string-template@~0.2.1:
   version "0.2.1"
@@ -11161,6 +11216,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-fest@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
+  integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
+
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -11511,6 +11571,11 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.3.0.tgz#65241ce355425f907f5d127bdb5e72c412ff830c"
+  integrity sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
- Add React Router
- Configure Jest testing suite:
1. Add `jest-watch-typeahead` package for easy testing suite navigation
2. Add `collectCoverageFrom` to jest configuration json to indicate where jest should look for tests

Frontend after commit (Initial frontend commit)
![image](https://user-images.githubusercontent.com/41226602/65391806-575c8180-dd3b-11e9-9b62-c0d88a5ef1db.png)
